### PR TITLE
Fix S01E02: “Sea Rose” → “See, Rose,” and merge cues 12–13

### DIFF
--- a/Fullmetal Alchemist - S01E02 - Body of the Sanctioned.srt
+++ b/Fullmetal Alchemist - S01E02 - Body of the Sanctioned.srt
@@ -46,1354 +46,1349 @@ such a stern name, Fullmetal.
 But it's literal.
 
 12
-00:02:27,030 --> 00:02:28,070
-Sea Robes.
-
-13
-00:02:28,210 --> 00:02:31,250
-Alchemists forbid their own
+00:02:27,030 --> 00:02:31,250
+See, Rose, alchemists forbid their own
 from transforming lead into gold.
 
-14
+13
 00:02:31,570 --> 00:02:33,570
 But there's one practice more taboo.
 
-15
+14
 00:02:33,930 --> 00:02:37,150
 A technique forbidden
 by man and nature itself.
 
-16
+15
 00:02:37,470 --> 00:02:38,270
 Alchemy.
 
-17
+16
 00:02:38,850 --> 00:02:40,730
 On human souls.
 
-18
+17
 00:02:43,490 --> 00:02:45,550
 You miserable little boys.
 
-19
+18
 00:02:45,930 --> 00:02:48,450
 Dabbling in human alchemy
 without knowing its penalty.
 
-20
+19
 00:02:48,450 --> 00:02:50,050
 You stepped on the toes of God!
 
-21
+20
 00:02:50,130 --> 00:02:51,450
 You don't know the story.
 
-22
+21
 00:02:51,660 --> 00:02:52,580
 Al.
 
-23
+22
 00:02:55,990 --> 00:02:59,990
 But we just wanted...
 
-24
+23
 00:03:03,300 --> 00:03:06,100
 We just wanted to see Mom's face again.
 
-25
+24
 00:03:06,660 --> 00:03:07,780
 See her smile.
 
-26
+25
 00:03:08,220 --> 00:03:10,120
 But you failed, didn't you?
 
-27
+26
 00:03:11,280 --> 00:03:12,080
 Yeah.
 
-28
+27
 00:03:12,400 --> 00:03:14,320
 I'd label that a failure, all right.
 
-29
+28
 00:03:14,500 --> 00:03:17,000
 Al lost his whole body
 and I lost an arm and a leg.
 
-30
+29
 00:03:17,320 --> 00:03:22,240
 I ignored every signpost because I
 was reckless and I wanted it bad enough.
 
-31
+30
 00:03:22,860 --> 00:03:27,140
 Rose, this is what happens when
 you try to bring back what's dead.
 
-32
+31
 00:03:28,320 --> 00:03:30,600
 You really want to go through with that?
 
-33
+32
 00:03:34,800 --> 00:03:36,500
 Don't let them worry you, Rose.
 
-34
+33
 00:03:36,820 --> 00:03:41,060
 You forget that the great sun god Leto
 has blessed me with the philosopher's stone.
 
-35
+34
 00:03:41,140 --> 00:03:44,960
 Besides, I have far more experience than
 these heretic boys did.
 
-36
+35
 00:03:45,020 --> 00:03:46,080
 Don't be stupid.
 
-37
+36
 00:03:46,300 --> 00:03:49,800
 No matter what kind of powers
 you have, some things can't be done.
 
-38
+37
 00:03:49,900 --> 00:03:52,620
 Oh, then why are you so
 anxious to get this stone?
 
-39
+38
 00:03:52,760 --> 00:03:57,460
 You want to beat the laws of equivalence
 just as I do and bring your mommy back.
 
-40
+39
 00:03:57,580 --> 00:03:58,740
 Wrong, holy man.
 
-41
+40
 00:04:00,220 --> 00:04:02,760
 All we want is to get
 our bodies normal again.
 
-42
+41
 00:04:02,761 --> 00:04:05,180
 See, we don't lie about what's possible.
 
-43
+42
 00:04:05,260 --> 00:04:06,440
 We didn't start a cult.
 
-44
+43
 00:04:06,741 --> 00:04:08,189
 ERRRRRRR
 
-45
+44
 00:04:08,200 --> 00:04:09,920
 We will ask one more time.
 
-46
+45
 00:04:10,140 --> 00:04:11,600
 Please give us the stone.
 
-47
+46
 00:04:12,880 --> 00:04:14,960
 You are damned, state alchemist.
 
-48
+47
 00:04:15,160 --> 00:04:17,520
 May the wrath of god fall upon your head.
 
-49
+48
 00:04:17,700 --> 00:04:19,520
 Stop hiding behind that crap.
 
-50
+49
 00:04:19,720 --> 00:04:21,780
 Get down here and I'll
 show you some wrath.
 
-51
+50
 00:04:28,840 --> 00:04:29,640
 Sinners!
 
-52
+51
 00:04:31,950 --> 00:04:36,950
 PEW! PEW! PEW! PEW! PEW! PEW! PEW!
 PEW! PEW! PEW! PEW! PEW! PEW! PEW!
 
-53
+52
 00:04:38,839 --> 00:04:40,639
 [Snickering]
 
-54
+53
 00:04:40,649 --> 00:04:41,849
 ERRR
 
-55
+54
 00:04:46,350 --> 00:04:47,230
 Close call.
 
-56
+55
 00:04:49,470 --> 00:04:50,410
 Father Cornello!
 
-57
+56
 00:04:50,610 --> 00:04:51,410
 Huh?
 
-58
+57
 00:04:52,930 --> 00:04:53,930
 You!
 
-59
+58
 00:04:56,089 --> 00:04:56,989
 Al!
 
-60
+59
 00:04:57,500 --> 00:04:58,320
 This way!
 
-61
+60
 00:04:58,900 --> 00:04:59,720
 Idiots!
 
-62
+61
 00:04:59,740 --> 00:05:01,160
 You're running into a dead end!
 
-63
+62
 00:05:01,940 --> 00:05:06,160
 Like I always say, if you can't
 find a door, make your own!
 
-64
+63
 00:05:14,170 --> 00:05:15,210
 After them!
 
-65
+64
 00:05:15,350 --> 00:05:16,150
 Now!
 
-66
+65
 00:05:16,890 --> 00:05:17,910
 Father?
 
-67
+66
 00:05:18,011 --> 00:05:19,630
 Is it true what they said?
 
-68
+67
 00:05:19,790 --> 00:05:22,490
 That ring you're wearing, are
 your miracles just alchemy?
 
-69
+68
 00:05:24,510 --> 00:05:28,410
 Just because you can explain a thing
 doesn't mean it's not the will of god, Rose.
 
-70
+69
 00:05:28,910 --> 00:05:32,850
 What matters is that I have been given
 the power to do things that no one else can.
 
-71
+70
 00:05:35,950 --> 00:05:37,430
 Let me show you.
 
-72
+71
 00:05:45,999 --> 00:05:46,999
 Rose.
 
-73
+72
 00:05:49,110 --> 00:05:50,010
 Cain!
 
-74
+73
 00:05:50,570 --> 00:05:51,870
 Rose.
 
-75
+74
 00:05:57,240 --> 00:05:59,720
 The sun god's rewarded
 you for your faith, Rose.
 
-76
+75
 00:05:59,820 --> 00:06:01,560
 Your true love soul has been resurrected.
 
-77
+76
 00:06:02,060 --> 00:06:03,820
 But the work is not finished yet.
 
-78
+77
 00:06:03,980 --> 00:06:05,820
 His body still needs a few more days.
 
-79
+78
 00:06:06,840 --> 00:06:08,360
 I always believed it.
 
-80
+79
 00:06:08,600 --> 00:06:10,880
 This really has been the work of god.
 
-81
+80
 00:06:11,280 --> 00:06:12,560
 If Ed knew...
 
-82
+81
 00:06:19,180 --> 00:06:21,680
 Why do they treat us like we're evil?
 
-83
+82
 00:06:21,740 --> 00:06:25,960
 If we really wanted the stone at all cost,
 we would have taken it by now.
 
-84
+83
 00:06:27,800 --> 00:06:32,740
 People of Lior, this evening a pair of
 unbelievers tried to take the life of the
 
-85
+84
 00:06:32,741 --> 00:06:33,740
 great prophet Cornello.
 
-86
+85
 00:06:34,400 --> 00:06:37,840
 One short and blonde,
 the other wearing armor.
 
-87
+86
 00:06:37,841 --> 00:06:40,620
 Father Cornello asks you
 all to stay in your homes.
 
-88
+87
 00:06:40,621 --> 00:06:42,000
 Damien, I'll tell you what I'll do.
 
-89
+88
 00:06:42,001 --> 00:06:43,420
 They found him on Goma Street.
 
-90
+89
 00:06:43,780 --> 00:06:46,220
 Please, take all necessary precautions.
 
-91
+90
 00:06:56,240 --> 00:06:57,620
 No question, guys.
 
-92
+91
 00:06:57,780 --> 00:06:58,580
 They're the ones.
 
-93
+92
 00:06:58,640 --> 00:07:00,980
 The short newcomer and his tin man.
 
-94
+93
 00:07:01,340 --> 00:07:03,840
 Who are you calling a
 mousy little pipsqueak?
 
-95
+94
 00:07:04,000 --> 00:07:05,040
 Nobody said that.
 
-96
+95
 00:07:05,080 --> 00:07:05,880
 Now back off.
 
-97
+96
 00:07:06,260 --> 00:07:09,280
 We got more important business to settle.
 
-98
+97
 00:07:10,700 --> 00:07:12,740
 What kind of depraved souls are you?
 
-99
+98
 00:07:12,820 --> 00:07:14,117
 How could you go after the prophet?
 
-100
+99
 00:07:14,420 --> 00:07:15,780
 We welcomed you here.
 
-101
+100
 00:07:15,920 --> 00:07:17,220
 You made us believe you were good.
 
-102
+101
 00:07:18,500 --> 00:07:21,080
 Look lady, I never asked you to believe
 anything.
 
-103
+102
 00:07:21,260 --> 00:07:22,060
 That's your priest.
 
-104
+103
 00:07:22,280 --> 00:07:23,260
 He's a phony.
 
-105
+104
 00:07:23,280 --> 00:07:24,580
 He's just using alchemy.
 
-106
+105
 00:07:25,040 --> 00:07:25,840
 Liar!
 
-107
+106
 00:07:28,500 --> 00:07:31,400
 Just now, my boyfriend spoke to me.
 
-108
+107
 00:07:31,920 --> 00:07:33,220
 Cornello's bringing him back.
 
-109
+108
 00:07:34,420 --> 00:07:36,740
 You mean old cain
 we lost in the accident?
 
-110
+109
 00:07:36,940 --> 00:07:38,000
 He was a good kid.
 
-111
+110
 00:07:38,200 --> 00:07:39,200
 Good for you rose.
 
-112
+111
 00:07:40,020 --> 00:07:41,160
 There, you see?
 
-113
+112
 00:07:41,220 --> 00:07:42,540
 He's not the first either.
 
-114
+113
 00:07:42,700 --> 00:07:44,256
 There've been many others who've come
 back.
 
-115
+114
 00:07:44,300 --> 00:07:44,920
 She's right.
 
-116
+115
 00:07:45,000 --> 00:07:45,460
 Yeah.
 
-117
+116
 00:07:45,480 --> 00:07:46,520
 That's not a miracle.
 
-118
+117
 00:07:46,521 --> 00:07:47,400
 Tell me what is.
 
-119
+118
 00:07:47,520 --> 00:07:50,240
 Has anyone actually seen
 these people close up?
 
-120
+119
 00:07:50,340 --> 00:07:53,100
 Cause I heard they all left town
 as soon as they were brought back.
 
-121
+120
 00:07:53,200 --> 00:07:54,000
 Look!
 
-122
+121
 00:07:57,180 --> 00:07:57,980
 Another one!
 
-123
+122
 00:07:58,500 --> 00:07:59,880
 A sun god statue!
 
-124
+123
 00:08:00,100 --> 00:08:01,680
 You wanna call him a phony now?
 
-125
+124
 00:08:02,380 --> 00:08:03,180
 Yes.
 
-126
+125
 00:08:14,340 --> 00:08:15,240
 Al!
 
-127
+126
 00:08:44,160 --> 00:08:45,500
 Give that back!
 
-128
+127
 00:08:45,720 --> 00:08:48,560
 So this is the official pocket watch of
 the state alchemist.
 
-129
+128
 00:08:48,860 --> 00:08:50,480
 Never seen one close.
 
-130
+129
 00:08:50,680 --> 00:08:54,300
 It's the reason you can do alchemy
 without a transmutation circle, isn't it?
 
-131
+130
 00:08:54,400 --> 00:08:55,980
 It amplifies all of your work.
 
-132
+131
 00:08:56,060 --> 00:08:58,060
 I think you'll be quite
 harmless without it.
 
-133
+132
 00:09:03,040 --> 00:09:08,040
 MUHAHAHAHAHA
 HAHAHAHAHAHA
 HAHAHAHAHA!
 
-134
+133
 00:09:17,360 --> 00:09:19,720
 How could I sleep after last night?
 
-135
+134
 00:09:24,180 --> 00:09:26,400
 Where's the... bell?
 
-136
+135
 00:09:38,410 --> 00:09:39,910
 Great, you came to feed me.
 
-137
+136
 00:09:39,990 --> 00:09:41,090
 And I thought you were mad.
 
-138
+137
 00:09:45,860 --> 00:09:48,200
 I hope he's real, Rose.
 
-139
+138
 00:09:48,320 --> 00:09:50,640
 I just don't want you to get disappointed.
 
-140
+139
 00:10:31,390 --> 00:10:35,430
 The real secret behind that
 philosopher's stone stays between us.
 
-141
+140
 00:10:35,610 --> 00:10:36,890
 Right, love?
 
-142
+141
 00:10:48,260 --> 00:10:49,320
 Sorry, Cain.
 
-143
+142
 00:10:49,360 --> 00:10:50,275
 I know you're healing.
 
-144
+143
 00:10:50,320 --> 00:10:52,020
 But I just needed to talk.
 
-145
+144
 00:10:52,240 --> 00:10:54,480
 So much has happened and I'm confused.
 
-146
+145
 00:10:56,580 --> 00:10:57,380
 Rose?
 
-147
+146
 00:11:05,380 --> 00:11:06,580
 I'm sorry, father.
 
-148
+147
 00:11:06,900 --> 00:11:09,040
 I shouldn't have taken
 the key without asking.
 
-149
+148
 00:11:09,160 --> 00:11:10,640
 I just needed to see.
 
-150
+149
 00:11:18,580 --> 00:11:19,380
 Oh!
 
-151
+150
 00:11:26,200 --> 00:11:27,260
 What's wrong, Rose?
 
-152
+151
 00:11:27,520 --> 00:11:28,400
 You got your wish.
 
-153
+152
 00:11:28,700 --> 00:11:31,900
 I'm afraid that even with the
 stone, I couldn't forge a human soul.
 
-154
+153
 00:11:32,100 --> 00:11:34,000
 I had to use the
 souls of these birds.
 
-155
+154
 00:11:34,500 --> 00:11:38,260
 You know, they can be quite
 adept at mimicking the human voice.
 
-156
+155
 00:11:39,520 --> 00:11:41,760
 You shouldn't have
 acted against me, Rose.
 
-157
+156
 00:11:41,760 --> 00:11:43,840
 You've fallen out of the Sun God's favor.
 
-158
+157
 00:11:49,400 --> 00:11:51,860
 Give the real Cain my best.
 
-159
+158
 00:11:54,400 --> 00:11:55,220
 Rose!
 
-160
+159
 00:11:55,221 --> 00:11:56,221
 Rooose!
 
-161
+160
 00:12:04,400 --> 00:12:07,240
 There's only one soul left who
 knows the secret of the stone.
 
-162
+161
 00:12:07,560 --> 00:12:08,740
 But not for long.
 
-163
+162
 00:12:17,880 --> 00:12:20,700
 I guess I don't need to
 tell you it's dangerous here.
 
-164
+163
 00:12:21,000 --> 00:12:21,800
 Come on.
 
-165
+164
 00:12:29,640 --> 00:12:32,880
 This little charade of yours
 will be found out soon enough.
 
-166
+165
 00:12:32,881 --> 00:12:37,360
 The faithful are not likely to distinguish
 between alchemy and the works of God.
 
-167
+166
 00:12:37,860 --> 00:12:38,660
 Really.
 
-168
+167
 00:12:38,780 --> 00:12:42,100
 As long as I'm bringing them happiness,
 what do they care where it comes from?
 
-169
+168
 00:12:43,820 --> 00:12:44,480
 Right.
 
-170
+169
 00:12:44,481 --> 00:12:47,460
 So what's in it for you, besides all the
 kowtowing?
 
-171
+170
 00:12:50,160 --> 00:12:52,040
 It's alchemy's basic principle.
 
-172
+171
 00:12:52,620 --> 00:12:56,160
 To obtain, you have to give up something
 of equal value.
 
-173
+172
 00:12:56,900 --> 00:13:01,320
 People say Ed's a prodigy, but that's just
 because he paid with enough effort.
 
-174
+173
 00:13:01,321 --> 00:13:03,480
 But how did you survive those statues?
 
-175
+174
 00:13:04,540 --> 00:13:05,380
 Easy, really.
 
-176
+175
 00:13:05,640 --> 00:13:06,680
 Ed handled it.
 
-177
+176
 00:13:07,600 --> 00:13:10,740
 The two of you really have
 paid a hefty price, haven't you?
 
-178
+177
 00:13:11,000 --> 00:13:12,260
 An arm and a leg.
 
-179
+178
 00:13:12,420 --> 00:13:13,240
 A body.
 
-180
+179
 00:13:14,040 --> 00:13:16,540
 And yet here you are
 now, trying to get it all back.
 
-181
+180
 00:13:17,820 --> 00:13:19,200
 What about your mom?
 
-182
+181
 00:13:19,700 --> 00:13:20,820
 What happened to her?
 
-183
+182
 00:13:21,680 --> 00:13:22,840
 I should get started.
 
-184
+183
 00:13:23,760 --> 00:13:24,720
 It's about time.
 
-185
+184
 00:13:27,180 --> 00:13:27,660
 What?
 
-186
+185
 00:13:27,900 --> 00:13:29,320
 Is it the money you're after?
 
-187
+186
 00:13:29,620 --> 00:13:30,060
 Edward?
 
-188
+187
 00:13:30,061 --> 00:13:32,580
 Oh, I can get all the money I want from
 the offerings.
 
-189
+188
 00:13:34,080 --> 00:13:35,760
 But you think too small.
 
-190
+189
 00:13:36,300 --> 00:13:40,500
 I'm making believers who would gladly
 throw away their very lives in my name.
 
-191
+190
 00:13:40,620 --> 00:13:41,420
 And why not?
 
-192
+191
 00:13:41,580 --> 00:13:43,240
 They believe I can resurrect them.
 
-193
+192
 00:13:43,440 --> 00:13:44,840
 They aren't afraid to die.
 
-194
+193
 00:13:45,480 --> 00:13:48,720
 There is no greater army
 than those with a holy call.
 
-195
+194
 00:13:49,220 --> 00:13:50,400
 Mark my words.
 
-196
+195
 00:13:50,640 --> 00:13:54,500
 In a few years, I'll have a following
 large enough to tear this country apart
 
-197
+196
 00:13:54,501 --> 00:13:57,280
 and rebuild it in my name!
 
-198
+197
 00:13:58,480 --> 00:14:00,040
 Makes no difference to me.
 
-199
+198
 00:14:00,040 --> 00:14:01,040
 What?
 
-200
+199
 00:14:01,160 --> 00:14:04,340
 After all, there's no real way to bring
 people back to life, right?
 
-201
+200
 00:14:04,420 --> 00:14:06,380
 Once you cut me down, I'm gone for good.
 
-202
+201
 00:14:06,620 --> 00:14:07,700
 I'm afraid that's right.
 
-203
+202
 00:14:08,020 --> 00:14:11,380
 Even with a Philosopher's Stone,
 I wouldn't dare try human alchemy.
 
-204
+203
 00:14:11,600 --> 00:14:12,680
 I'd end up like you.
 
-205
+204
 00:14:13,120 --> 00:14:17,160
 And why would a king risk his life for the
 sake of his mindless pawns?
 
-206
+205
 00:14:17,320 --> 00:14:18,700
 Wait a second...
 
-207
+206
 00:14:21,560 --> 00:14:22,360
 Gee...
 
-208
+207
 00:14:26,800 --> 00:14:27,900
 WHAT!
 
-209
+208
 00:14:28,401 --> 00:14:29,940
 How long has that thing been on?
 
-210
+209
 00:14:30,700 --> 00:14:34,560
 Long enough for the mindless pawns tearing
 this country apart comment, I think.
 
-211
+210
 00:14:35,080 --> 00:14:37,120
 How did you get my broadcasting equipment?
 
-212
+211
 00:14:37,840 --> 00:14:38,860
 Al rigged it up.
 
-213
+212
 00:14:39,100 --> 00:14:41,280
 I know, you smashed him into pieces.
 
-214
+213
 00:14:41,480 --> 00:14:44,120
 But that was just some metal I whipped up
 to look like him.
 
-215
+214
 00:14:44,320 --> 00:14:45,120
 Pretty clever, huh?
 
-216
+215
 00:14:45,320 --> 00:14:46,780
 No, my children, he lies!
 
-217
+216
 00:14:46,980 --> 00:14:47,840
 Don't believe him!
 
-218
+217
 00:14:58,650 --> 00:15:02,330
 Oh, and by the way, I don't get
 my skills from a pocket watch.
 
-219
+218
 00:15:19,560 --> 00:15:21,680
 Father, that broadcast,
 I don't understand.
 
-220
+219
 00:15:21,920 --> 00:15:23,000
 Tell us what's going on.
 
-221
+220
 00:15:27,540 --> 00:15:31,600
 My children, the non-believer has used his
 science to impersonate me.
 
-222
+221
 00:15:31,601 --> 00:15:34,080
 It is a conspiracy of the devil!
 
-223
+222
 00:15:34,460 --> 00:15:38,120
 But witness as the great Leto
 redeems me with his vengeful light!
 
-224
+223
 00:15:40,620 --> 00:15:42,000
 Behold God's power!
 
-225
+224
 00:15:51,200 --> 00:15:52,800
 That has to be a miracle!
 
-226
+225
 00:15:53,000 --> 00:15:54,020
 What else could it be?
 
-227
+226
 00:15:57,260 --> 00:15:59,160
 I'm warning you, give it up.
 
-228
+227
 00:15:59,420 --> 00:16:02,380
 You didn't fool me with that little
 display down there.
 
-229
+228
 00:16:02,580 --> 00:16:06,080
 Without this, the only alchemy you
 can perform is to your own metal arm.
 
-230
+229
 00:16:06,140 --> 00:16:06,980
 Know what?
 
-231
+230
 00:16:07,040 --> 00:16:10,900
 You're not the only one who can't stand
 doubters preach.
 
-233
+231
 00:16:16,810 --> 00:16:19,010
 Here's the real Hammer of God!
 
-234
+232
 00:16:31,200 --> 00:16:32,520
 I don't believe it
 
-235
+233
 00:16:32,540 --> 00:16:36,120
 Not even the philosopher's stone
 can move something as big as that.
 
-236
+234
 00:16:38,960 --> 00:16:41,900
 Rings and watches
 have nothing to do with it.
 
-237
+235
 00:16:42,020 --> 00:16:44,540
 My brother's the Fullmetal alchemist.
 
-238
+236
 00:16:50,609 --> 00:16:52,309
 AAAAAAAHHHHHHH!
 
-239
+237
 00:17:12,720 --> 00:17:14,020
 No!
 I wont let you have it.
 
-240
+238
 00:17:14,050 --> 00:17:15,410
 You can't take the stone!
 
-241
+239
 00:17:25,290 --> 00:17:26,330
 What the?
 
-242
+240
 00:17:26,490 --> 00:17:27,350
 It's recoiling.
 
-243
+241
 00:17:37,400 --> 00:17:40,480
 An imitation?
 
-244
+242
 00:17:41,840 --> 00:17:48,420
 After all this... all the trouble you put
 me through... even the stones are fake?
 
-245
+243
 00:17:48,960 --> 00:17:52,040
 Stop jerking me AROOOOOUND!
 
-246
+244
 00:18:00,920 --> 00:18:03,480
 Just another wild goose chase.
 
-247
+245
 00:18:03,540 --> 00:18:07,120
 And here I thought we could
 finally put you back in the flesh again.
 
-248
+246
 00:18:07,420 --> 00:18:08,320
 No, brother.
 
-249
+247
 00:18:08,460 --> 00:18:10,040
 You'll be the first we fix.
 
-250
+248
 00:18:10,620 --> 00:18:12,780
 That automail's so tough on you.
 
-251
+249
 00:18:13,160 --> 00:18:15,920
 Nothing left to do but
 start the search again.
 
-252
+250
 00:18:17,440 --> 00:18:19,200
 You should never have come here!
 
-253
+251
 00:18:19,210 --> 00:18:20,110
 Huh?
 
-254
+252
 00:18:20,120 --> 00:18:22,020
 Father Cornello gave us hope.
 
-255
+253
 00:18:22,060 --> 00:18:24,160
 What right did you have to take that away?
 
-256
+254
 00:18:24,260 --> 00:18:28,020
 With him, we believed we could do
 anything, even bring back the dead.
 
-257
+255
 00:18:28,620 --> 00:18:29,980
 We're a desert village!
 
-258
+256
 00:18:30,240 --> 00:18:31,380
 We had nothing before that!
 
-259
+257
 00:18:33,040 --> 00:18:36,000
 You're saying we should have
 just let everything go on as it was?
 
-260
+258
 00:18:37,040 --> 00:18:37,900
 Well, why not?
 
-261
+259
 00:18:38,680 --> 00:18:41,880
 What do I have to live for now
 that I know Cain won't come back?
 
-262
+260
 00:18:42,940 --> 00:18:44,360
 You tell me that, Ed!
 
-263
+261
 00:18:48,710 --> 00:18:50,630
 You'll have to decide for yourself.
 
-264
+262
 00:18:51,150 --> 00:18:52,170
 Walk on your own.
 
-265
+263
 00:18:52,610 --> 00:18:53,550
 Move forward.
 
-266
+264
 00:18:54,250 --> 00:18:56,690
 You've got a good,
 strong pair of legs, Rose.
 
-267
+265
 00:18:56,770 --> 00:18:57,970
 You should get up and use them.
 
-268
+266
 00:19:09,510 --> 00:19:11,350
 Brother was trying to help you.
 
-269
+267
 00:19:11,410 --> 00:19:13,910
 He just doesn't always
 handle things well.
 
-270
+268
 00:19:13,950 --> 00:19:15,310
 Just go away, would you?
 
-271
+269
 00:19:16,590 --> 00:19:19,690
 You can still believe in hope,
 Rose.
 
-272
+270
 00:19:20,630 --> 00:19:21,830
 I still do.
 
-273
+271
 00:19:26,480 --> 00:19:27,800
 AHH What's going on here?
 
-274
+272
 00:19:28,100 --> 00:19:29,400
 That damn boy was right!
 
-275
+273
 00:19:29,480 --> 00:19:31,900
 The ring you gave me wasn't the real
 Philosopher's Stone!
 
-276
+274
 00:19:32,360 --> 00:19:33,620
 Of course not.
 
-277
+275
 00:19:33,860 --> 00:19:36,220
 This village is nothing but a juicy bait.
 
-278
+276
 00:19:37,180 --> 00:19:39,900
 As rumors spread, real
 alchemists who've searched
 
-279
+277
 00:19:39,901 --> 00:19:42,160
 for the stone all their
 lives will come to me.
 
-280
+278
 00:19:42,640 --> 00:19:43,720
 And then...
 
-281
+279
 00:19:44,200 --> 00:19:45,240
 Cursed souls!
 
-282
+280
 00:19:45,300 --> 00:19:46,100
 Who are you really?
 
-283
+281
 00:19:46,300 --> 00:19:47,380
 What are you after?
 
-284
+282
 00:19:47,840 --> 00:19:48,780
 Come on, Lust.
 
-285
+283
 00:19:48,980 --> 00:19:51,440
 Isn't it time you let me
 eat the old preacher?
 
-286
+284
 00:19:53,655 --> 00:19:56,955
 [Wet macaroni noises]
 
-287
+285
 00:20:01,490 --> 00:20:03,410
 Where'd that miserable preach run off to?
 
-288
+286
 00:20:03,610 --> 00:20:04,410
 Rotten fake.
 
-289
+287
 00:20:04,570 --> 00:20:06,030
 I can't believe we were duped.
 
-290
+288
 00:20:06,310 --> 00:20:09,010
 What do you think that's about?
 
-291
+289
 00:20:09,630 --> 00:20:10,430
 I don't know.
 
-292
+290
 00:20:10,810 --> 00:20:12,650
 Something messed
 up's been going on here.
 
-293
+291
 00:20:16,050 --> 00:20:17,310
 Father Cornello?
 
-294
+292
 00:20:28,389 --> 00:20:29,389
 A miracle.
 
-295
+293
 00:20:29,600 --> 00:20:31,680
 How do you know it's not another trick?
 
-296
+294
 00:20:31,820 --> 00:20:32,969
 You don't trick things to life.
 
-297
+295
 00:20:33,940 --> 00:20:37,340
 It seems the devil has worked his
 wickedness while I was gone away.
 
-298
+296
 00:20:37,620 --> 00:20:39,320
 But I'm glad that you're all safe.
 
-299
+297
 00:20:40,640 --> 00:20:41,980
 I knew it, Cornello.
 
-300
+298
 00:20:42,120 --> 00:20:45,080
 I knew someone who gave us
 so many joys couldn't be bad.
 
-301
+299
 00:20:55,670 --> 00:20:56,590
 Good, Envy.
 
-302
+300
 00:20:56,630 --> 00:21:00,270
 I'm sorry, but we'll have to ask you
 to keep that form for a little while.
 
-303
+301
 00:21:00,670 --> 00:21:01,990
 Long live Cornello!
 
-304
+302
 00:21:02,410 --> 00:21:03,950
 Long live Cornello!
 
-305
+303
 00:21:09,130 --> 00:21:11,810
 Before we go, Rose, listen to me.
 
-306
+304
 00:21:12,250 --> 00:21:16,630
 My brother and I have seen all sorts
 of things over our years of searching.
 
-307
+305
 00:21:17,130 --> 00:21:19,170
 And I need to tell you about them.
 
-308
+306
 00:21:19,850 --> 00:21:21,910
 So you don't repeat our mistakes.
 
-309
+307
 00:21:25,890 --> 00:21:31,330
 We were born and raised in a small
 village east of Central named Resembool.
 
-310
+308
 00:21:33,750 --> 00:21:35,390
 That's where it all began.
 
-311
+309
 00:21:37,050 --> 00:21:41,470
 Hahahaha
 mom, look mom, look
 
-312
+310
 00:21:41,470 --> 00:21:42,450
 What you got there?
 
-313
+311
 00:21:42,770 --> 00:21:43,570
 See?
 
-314
+312
 00:21:45,570 --> 00:21:47,590
 Brother made it.
 Isn't it awesome?
 
-315
+313
 00:21:47,910 --> 00:21:49,790
 I can still only do this one.
 
-316
+314
 00:21:51,250 --> 00:21:53,690
 Well, I think they're both gorgeous.
 
-317
+315
 00:21:53,690 --> 00:21:56,210
 You two really are his kids, all right.
 
-318
+316
 00:22:02,480 --> 00:22:06,200
 Humankind cannot gain anything
 without first giving something in return.
 
-319
+317
 00:22:06,480 --> 00:22:09,880
 To obtain, something of
 equal value must be lost.
 
-320
+318
 00:22:09,881 --> 00:22:13,640
 That is alchemy's first
 law of equivalent exchange.
 
-321
+319
 00:22:16,600 --> 00:22:22,520
 In those days, we really believed
 that to be the world's one and only truth.
 
-322
+320
 00:23:38,800 --> 00:23:40,080
 Fulmetal Alchemist.
 
-323
+321
 00:23:40,120 --> 00:23:41,480
 Episode Three, Mother.
 
-324
+322
 00:23:41,720 --> 00:23:44,200
 What I remember most were her lullabies.
 
-325
+323
 00:23:44,300 --> 00:23:48,740
 For Ed, it was her stew, even
 though I thought it just tasted like milk.
 
-326
+324
 00:23:48,920 --> 00:23:52,480
 We loved her more than anything,
 and that's why we had to try.
-


### PR DESCRIPTION
## Summary

Corrects the misheard phrase (“Sea Robes/Sea Rose”) to the proper vocative **“See, Rose,”** and adjusts timing by merging cues 12–13 into a single cue. Cue 11 remains unchanged.

## What Changed

* Text: `Sea Robes` → `See, Rose,` (vocative)
* Structure: cues **12** and **13** merged into **12**
* Timing: `00:02:27,030 --> 00:02:31,250` now spans the full sentence
* No other dialogue or timestamps modified

## Rationale

The audio addresses Rose directly (“See, Rose,”). Keeping the sentence in one cue improves readability and preserves natural timing.

## Before

```srt
11
00:02:24,930 --> 00:02:26,070
But it's literal.

12
00:02:27,030 --> 00:02:28,070
Sea Robes.

13
00:02:28,210 --> 00:02:31,250
Alchemists forbid their own
from transforming lead into gold.
```

## After

```srt
11
00:02:24,930 --> 00:02:26,070
But it's literal.

12
00:02:27,030 --> 00:02:31,250
See, Rose, alchemists forbid their own
from transforming lead into gold.
```

## Files

* `Fullmetal Alchemist - S01E02 - Body of the Sanctioned.srt`

## Testing

* Played back 02:24–02:32 to confirm natural sync.
* Verified two-line wrapping in the player.

## Risks

Low. Localized text/timing change; no downstream timecodes affected.

## Related Commit

```
Fix: S01E02 subs 'Sea Rose' timing and text

- Correct misheard phrase: 'Sea Robes' -> 'See, Rose,' (vocative).
- Merge cues 12–13 into a single line and adjust timing.
- New cue 12: 00:02:27,030 --> 00:02:31,250 with full sentence.
- Keep cue 11 timing: 00:02:24,930 --> 00:02:26,070.
- No other changes.
```
